### PR TITLE
fix: avoid debouncing grand total calculation

### DIFF
--- a/packages/app/src/lib/components/cart/grand-total-display.svelte
+++ b/packages/app/src/lib/components/cart/grand-total-display.svelte
@@ -8,7 +8,7 @@
 
 	let grandTotal: Awaited<ReturnType<typeof cart.calculateGrandTotal>> | null = null
 
-	$: $cart && cart.calculateGrandTotal().then((total) => grandTotal = total)
+	$: $cart && cart.calculateGrandTotal().then((total) => (grandTotal = total))
 </script>
 
 <div class="cart-totals mt-4 p-4 bg-gray-100 rounded-lg">

--- a/packages/app/src/lib/components/cart/grand-total-display.svelte
+++ b/packages/app/src/lib/components/cart/grand-total-display.svelte
@@ -2,17 +2,13 @@
 	import { Button } from '$lib/components/ui/button'
 	import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '$lib/components/ui/collapsible'
 	import { cart } from '$lib/stores/cart'
-	import { debounce, formatSats } from '$lib/utils'
+	import { formatSats } from '$lib/utils'
 
 	export let showActions = false
 
 	let grandTotal: Awaited<ReturnType<typeof cart.calculateGrandTotal>> | null = null
 
-	$: updateGrandTotal($cart)
-
-	const updateGrandTotal = debounce(async () => {
-		grandTotal = await cart.calculateGrandTotal()
-	}, 300)
+	$: $cart && cart.calculateGrandTotal().then((total) => grandTotal = total)
 </script>
 
 <div class="cart-totals mt-4 p-4 bg-gray-100 rounded-lg">

--- a/packages/app/src/lib/components/cart/product-in-cart.svelte
+++ b/packages/app/src/lib/components/cart/product-in-cart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { CartProduct } from '$lib/stores/cart'
-	import { debounce, formatPrice, stringToHexColor } from '$lib/utils'
+	import { formatPrice, stringToHexColor } from '$lib/utils'
 	import { createEventDispatcher } from 'svelte'
 	import { toast } from 'svelte-sonner'
 
@@ -12,21 +12,21 @@
 
 	const dispatch = createEventDispatcher()
 
-	const handleIncrement = debounce(() => {
+	const handleIncrement = () => {
 		if (product.amount < product.stockQuantity) {
 			dispatch('increment', { action: 'increment' })
 		}
-	}, 200)
+	}
 
-	const handleDecrement = debounce(() => {
+	const handleDecrement = () => {
 		if (product.amount > 1) {
 			dispatch('decrement', { action: 'decrement' })
 		}
-	}, 200)
+	}
 
-	const debouncedSetAmount = debounce((newAmount) => {
+	const debouncedSetAmount = (newAmount: number) => {
 		dispatch('setAmount', { action: 'setAmount', amount: newAmount })
-	}, 500)
+	}
 
 	function handleSetAmount(e: Event) {
 		const newAmount = Math.min(Math.max(1, parseInt((e.target as HTMLInputElement).value) || 1), product.stockQuantity)

--- a/packages/app/src/lib/fetch/users.mutations.ts
+++ b/packages/app/src/lib/fetch/users.mutations.ts
@@ -102,10 +102,17 @@ export const createUserFromNostrMutation = createMutation(
 	{
 		mutationKey: [],
 		mutationFn: async ({ profile, pubkey }: { profile: NDKUserProfile; pubkey: string }) => {
-			const user = await createRequest(`POST /api/v1/users/${pubkey}`, {
-				body: profile,
-			})
-			return user
+			try {
+				const user = await createRequest(`POST /api/v1/users/${pubkey}`, {
+					body: profile,
+				})
+				return user
+			} catch (e) {
+				const user = await createRequest(`PUT /api/v1/users/${pubkey}`, {
+					body: profile,
+				})
+				return user
+			}
 		},
 		onSuccess: (data: User | null) => {
 			if (data?.id) {

--- a/packages/app/src/lib/nostrSubs/data-aggregator.ts
+++ b/packages/app/src/lib/nostrSubs/data-aggregator.ts
@@ -52,7 +52,6 @@ async function processBatch(userIds: string[], allowRegister: boolean) {
 	for (const userId of batchUserIds) {
 		const userExists = await checkIfUserExists(userId)
 		const shouldRegisterUser = await shouldRegister(allowRegister, userExists, userId)
-
 		if (shouldRegisterUser) {
 			let user = Array.from(userQueue).find((u) => u.id === userId)
 			if (!user) user = (await resolveQuery(() => createUserByIdQuery(userId))) ?? undefined
@@ -137,7 +136,7 @@ export async function checkIfOldProfile(userId: string, updatedAt?: number) {
 	const elapsedTime = getElapsedTimeInDays(updatedAt)
 	if (elapsedTime > 5) {
 		const { userProfile: newUserProfile } = await fetchUserData(userId)
-		if (newUserProfile) {
+		if (newUserProfile && updatedAt > Number(newUserProfile.created_at)) {
 			await handleUserNostrData(newUserProfile, userId)
 		}
 	}


### PR DESCRIPTION
With the latest updates on currency conversion, the cost of calculating is way lower than before and we do not need debouncing. 

this would help creating a instantaneous experience. 

Resolves #425 