### PR TITLE
fix: stall/product currency mismatch

### DIFF
--- a/packages/app/src/lib/components/product/product-item.svelte
+++ b/packages/app/src/lib/components/product/product-item.svelte
@@ -9,7 +9,7 @@
 	import { openDrawerForProduct } from '$lib/stores/drawer-ui'
 	import ndkStore from '$lib/stores/ndk'
 	import { formatSats, parseCoordinatesString, stringToHexColor } from '$lib/utils'
-	import { Edit, MoreVertical, ShoppingCart } from 'lucide-svelte'
+	import { Edit, MoreVertical } from 'lucide-svelte'
 
 	import Spinner from '../assets/spinner.svelte'
 	import { Badge } from '../ui/badge'

--- a/packages/app/src/lib/fetch/stalls.mutations.ts
+++ b/packages/app/src/lib/fetch/stalls.mutations.ts
@@ -79,6 +79,9 @@ export const updateStallFromNostrEvent = createMutation(
 				await queryClient.invalidateQueries({
 					queryKey: shippingKeys.byStall(data.id),
 				})
+				await queryClient.invalidateQueries({
+					queryKey: productKeys.filtered({ userId: data.userId }),
+				})
 			}
 		},
 	},

--- a/packages/app/src/lib/server/stalls.service.ts
+++ b/packages/app/src/lib/server/stalls.service.ts
@@ -512,6 +512,15 @@ export const updateStall = async (stallId: string, stallEvent: NostrEvent): Prom
 				.where(and(eq(eventTags.eventId, stallId), eq(eventTags.tagName, 'image')))
 				.limit(1)
 
+			if (parsedStall.currency) {
+				await tx
+					.update(products)
+					.set({
+						currency: parsedStall.currency,
+					})
+					.where(eq(products.stallId, stallId))
+			}
+
 			return {
 				id: stallResult.id,
 				name: stallResult.name,


### PR DESCRIPTION
Right now, just updating the currency for the related products in the db when a stall is updated. 