### PR TITLE
chore: make placeholder consistent

### DIFF
--- a/packages/app/src/lib/components/product/create-edit.svelte
+++ b/packages/app/src/lib/components/product/create-edit.svelte
@@ -368,7 +368,7 @@
 									class={`border-2 border-black ${validationErrors['quantity'] ? 'ring-2 ring-red-500' : ''}`}
 									type="number"
 									name="quantity"
-									placeholder="10"
+									placeholder="e.g. 10"
 								/>
 								{#if validationErrors['quantity']}
 									<p class="text-red-500 text-sm mt-1">


### PR DESCRIPTION
Changed quantity field placeholder in product modal form to be the same as price so no confusion