### PR TITLE
fix: removed import of `ScrollArea` in `drawer.svelte`

### DIFF
--- a/packages/app/src/lib/components/drawer.svelte
+++ b/packages/app/src/lib/components/drawer.svelte
@@ -2,7 +2,6 @@
 	import { pushState, replaceState } from '$app/navigation'
 	import CreateEditProduct from '$lib/components/product/create-edit.svelte'
 	import CreateEditStall from '$lib/components/stalls/create-edit.svelte'
-	import { ScrollArea } from '$lib/components/ui/scroll-area/index.js'
 	import * as Sheet from '$lib/components/ui/sheet/index.js'
 	import { createProductQuery } from '$lib/fetch/products.queries'
 	import { createStallQuery } from '$lib/fetch/stalls.queries'

--- a/packages/app/src/lib/utils.ts
+++ b/packages/app/src/lib/utils.ts
@@ -82,21 +82,21 @@ export const flyAndScale = (node: Element, params: FlyAndScaleParams = { y: -8, 
 	}
 }
 
-export function clickOutside(element: HTMLElement, callbackFunction: () => void) {
-	function onClick(event: MouseEvent) {
-		if (!element.contains(event.target as Node)) {
-			callbackFunction()
+export function clickOutside(node: HTMLElement, callback: () => void) {
+	const handleClick = (event: MouseEvent) => {
+		if (node.isConnected && !node.contains(event.target as Node)) {
+			callback()
 		}
 	}
 
-	document.body.addEventListener('click', onClick)
+	document.addEventListener('click', handleClick, true)
 
 	return {
-		update(newCallbackFunction: () => void) {
-			callbackFunction = newCallbackFunction
+		update(newCallback: () => void) {
+			callback = newCallback
 		},
 		destroy() {
-			document.body.removeEventListener('click', onClick)
+			document.removeEventListener('click', handleClick, true)
 		},
 	}
 }


### PR DESCRIPTION
- refactored `clickOutside` function in `utils.ts` for improved clarity and efficiency:
  - changed parameter names
  - adjusted event listener management to improve performance
  - used `node.isConnected` to check if the element is still in the DOM