### PR TITLE
Allow hardware password managers to be listed in the marketplace

### DIFF
--- a/packages/database/fixtures.ts
+++ b/packages/database/fixtures.ts
@@ -79,5 +79,4 @@ export const FORBIDDEN_WORDS = new Set([
 	'placeholder',
 	'lorem',
 	'admin',
-	'password',
 ])


### PR DESCRIPTION
Partially resolves https://github.com/PlebeianApp/plebeian.market/issues/740

Removes the forbidden word, but it does not address the problem that the error message does not disclose which word the user entered which was forbidden.